### PR TITLE
Solve invalid_protection_access_token issue

### DIFF
--- a/kong/plugins/gluu-oauth-pep/access.lua
+++ b/kong/plugins/gluu-oauth-pep/access.lua
@@ -71,14 +71,14 @@ end
 -- upon success returns only introspect_response,
 -- otherwise return nil, status, err
 function hooks.introspect_token(self, conf, token)
-    kong_auth_pep_common.get_protection_token(self, conf)
+    local ptoken = kong_auth_pep_common.get_protection_token(self, conf)
 
     local response = oxd.introspect_access_token(conf.oxd_url,
         {
             oxd_id = conf.oxd_id,
             access_token = token,
         },
-        self.access_token.token)
+        ptoken)
     local status = response.status
 
     if status == 403 then

--- a/kong/plugins/gluu-oauth-pep/handler.lua
+++ b/kong/plugins/gluu-oauth-pep/handler.lua
@@ -1,6 +1,5 @@
 local BasePlugin = require "kong.plugins.base_plugin"
 local access = require "kong.plugins.gluu-oauth-pep.access"
-local lrucache = require "resty.lrucache.pureffi"
 
 local handler = BasePlugin:extend()
 handler.PRIORITY = 999
@@ -14,9 +13,6 @@ function handler:new()
     local name_prefix = "gluu_oauth_"
     self.metric_client_authenticated = name_prefix .. "client_authenticated"
     self.metric_client_granted = name_prefix .. "client_granted"
-
-    -- access token should be per plugin instance
-    self.access_token = { expire = 0 }
 end
 
 function handler:access(config)

--- a/kong/plugins/gluu-uma-pep/access.lua
+++ b/kong/plugins/gluu-uma-pep/access.lua
@@ -108,9 +108,9 @@ function hooks.get_path_by_request_path_method(self, conf, request_path, method)
 end
 
 function hooks.no_token_protected_path(self, conf, protected_path, method)
-    kong_auth_pep_common.get_protection_token(self, conf)
+    local ptoken = kong_auth_pep_common.get_protection_token(self, conf)
 
-    local check_access_no_rpt_response = try_check_access(conf, protected_path, method, nil, self.access_token.token)
+    local check_access_no_rpt_response = try_check_access(conf, protected_path, method, nil, ptoken)
 
     if check_access_no_rpt_response.access == "denied" then
         kong.log.debug("Set WWW-Authenticate header with ticket")
@@ -123,9 +123,9 @@ function hooks.no_token_protected_path(self, conf, protected_path, method)
 end
 
 function hooks.introspect_token(self, conf, token)
-    kong_auth_pep_common.get_protection_token(self, conf)
+    local ptoken = kong_auth_pep_common.get_protection_token(self, conf)
 
-    local introspect_rpt_response_data = try_introspect_rpt(conf, token, self.access_token.token)
+    local introspect_rpt_response_data = try_introspect_rpt(conf, token, ptoken)
     if not introspect_rpt_response_data.active then
         return nil, 401, "Invalid access token provided in Authorization header"
     end
@@ -145,9 +145,9 @@ function hooks.build_cache_key(method, path, token)
 end
 
 function hooks.is_access_granted(self, conf, protected_path, method, scope_expression, _, rpt)
-    kong_auth_pep_common.get_protection_token(self, conf)
+    local ptoken = kong_auth_pep_common.get_protection_token(self, conf)
 
-    local check_access_response = try_check_access(conf, protected_path, method, rpt, self.access_token.token)
+    local check_access_response = try_check_access(conf, protected_path, method, rpt, ptoken)
 
     return check_access_response.access == "granted"
 end

--- a/kong/plugins/gluu-uma-pep/handler.lua
+++ b/kong/plugins/gluu-uma-pep/handler.lua
@@ -13,9 +13,6 @@ function handler:new()
   local name_prefix = "gluu_uma_"
   self.metric_client_authenticated = name_prefix .. "client_authenticated"
   self.metric_client_granted = name_prefix .. "client_granted"
-
-    -- access token should be per plugin instance
-  self.access_token = { expire = 0 }
 end
 
 function handler:access(config)

--- a/t/specs/gluu-oauth-pep/oxd-model9.lua
+++ b/t/specs/gluu-oauth-pep/oxd-model9.lua
@@ -1,0 +1,199 @@
+local model
+model = {
+    -- array part start, scenario
+
+    -- #1, client register itself
+    {
+        expect = "/register-site",
+        required_fields = {
+            "scope",
+            "op_host",
+            "authorization_redirect_uri",
+            "client_name",
+            "grant_types",
+            -- "bla-bla", -- uncomment and check that test fail
+        },
+        response = {
+            oxd_id = "bcad760f-91ba-46e1-a020-05e4281d91b6",
+            client_id_of_oxd_id = "@!1736.179E.AA60.16B2!0001!8F7C.B9AB!0008!A2BB.9AE6.AAA4",
+            op_host = "https://example.com",
+            setup_client_oxd_id = "qwerty",
+            client_id = "@!1736.179E.AA60.16B2!0001!8F7C.B9AB!0008!A2BB.9AE6.5F14.B387",
+            client_secret = "f436b936-03fc-433f-9772-53c2bc9e1c74",
+            client_registration_access_token = "d836df94-44b0-445a-848a-d43189839b17",
+            client_registration_client_uri = "https://<op-hostname>/oxauth/restv1/register?client_id=@!1736.179E.AA60.16B2!0001!8F7C.B9AB!0008!A2BB.9AE6.5F14.B387",
+        },
+        response_callback = function(response)
+            response.client_id_issued_at = ngx.now()
+            response.client_secret_expires_at = ngx.now() + 60 * 60
+        end,
+    },
+    -- #2, client request access token
+    {
+        expect = "/get-client-token",
+        required_fields = {
+            "client_id",
+            "client_secret",
+            "op_host",
+        },
+        request_check = function(json)
+            assert(json.client_id == model[1].response.client_id)
+            assert(json.client_secret == model[1].response.client_secret)
+        end,
+        response = {
+            scope = { "openid", "profile", "email" },
+            access_token = "b75434ff-f465-4b70-92e4-b7ba6b6c58f2",
+            expires_in = 299,
+        }
+    },
+    -- #3, client register itself
+    {
+        expect = "/register-site",
+        required_fields = {
+            "scope",
+            "op_host",
+            "authorization_redirect_uri",
+            "client_name",
+            "grant_types",
+        },
+        response = {
+            oxd_id = "bcad760f-91ba-46e1-a020-05e4281d91b7",
+            client_id_of_oxd_id = "@!1736.179E.AA60.16B2!0001!8F7C.B9AB!0008!A2BB.9AE6.AAA4",
+            op_host = "https://example.com",
+            setup_client_oxd_id = "qwerty",
+            client_id = "@!1736.179E.AA60.16B2!0001!8F7C.B9AB!0008!A2BB.9AE6.5F14.B388",
+            client_secret = "f436b936-03fc-433f-9772-53c2bc9e1c77",
+            client_registration_access_token = "d836df94-44b0-445a-848a-d43189839b17",
+            client_registration_client_uri = "https://<op-hostname>/oxauth/restv1/register?client_id=@!1736.179E.AA60.16B2!0001!8F7C.B9AB!0008!A2BB.9AE6.5F14.B387",
+        },
+        response_callback = function(response)
+            response.client_id_issued_at = ngx.now()
+            response.client_secret_expires_at = ngx.now() + 60 * 60
+        end,
+    },
+    -- #4, client request access token
+    {
+        expect = "/get-client-token",
+        required_fields = {
+            "client_id",
+            "client_secret",
+            "op_host",
+        },
+        request_check = function(json)
+            assert(json.client_id == model[3].response.client_id)
+            assert(json.client_secret == model[3].response.client_secret)
+        end,
+        response = {
+            scope = { "openid", "profile", "email" },
+            access_token = "b75434ff-f465-4b70-92e4-b7ba6b6c58f9",
+            expires_in = 299,
+        }
+    },
+
+    -- #5, plugin request access token
+    {
+        expect = "/get-client-token",
+        required_fields = {
+            "client_id",
+            "client_secret",
+            "op_host",
+        },
+        request_check = function(json)
+            assert(json.client_id == model[1].response.client_id)
+            assert(json.client_secret == model[1].response.client_secret)
+            local scope = json.scope
+            assert(#scope == 2)
+            for i =1, 2 do
+                assert((scope[i] == "oxd") or (scope[i] == "openid"))
+            end
+        end,
+        response = {
+            scope = { "openid", "profile", "email" },
+            access_token = "b75434ff-f465-4b70-92e4-b7ba6b6c58f3",
+            expires_in = 299,
+        }
+    },
+    -- #6, plugin check the client token
+    {
+        expect = "/introspect-access-token",
+        required_fields = {
+            "oxd_id",
+            "access_token",
+        },
+        request_check = function(json, token)
+            assert(json.oxd_id == model[1].response.oxd_id)
+            assert(json.access_token == model[2].response.access_token)
+            assert(token == model[5].response.access_token, 403)
+        end,
+        response = {
+            active = true,
+            client_id = "@!1736.179E.AA60.16B2!0001!8F7C.B9AB!0008!A2BB.9AE6.5F14.B387", -- should be the same as return by register-site
+            username = "John Black",
+            scope = { "openid" },
+            token_type = "bearer",
+            sub = "jblack",
+            aud = "l238j323ds-23ij4",
+            iss = "https://as.gluu.org/",
+            --acr_values": ["basic","duo"],
+            --extension_field": "twenty-seven",
+        },
+        response_callback = function(response)
+            response.exp = ngx.now() + 60 * 60
+            response.iat = ngx.now()
+        end,
+    },
+    -- #7, plugin request access token
+    {
+        expect = "/get-client-token",
+        required_fields = {
+            "client_id",
+            "client_secret",
+            "op_host",
+        },
+        request_check = function(json)
+            assert(json.client_id == model[3].response.client_id)
+            assert(json.client_secret == model[3].response.client_secret)
+            local scope = json.scope
+            assert(#scope == 2)
+            for i =1, 2 do
+                assert((scope[i] == "oxd") or (scope[i] == "openid"))
+            end
+        end,
+        response = {
+            scope = { "openid", "profile", "email" },
+            access_token = "b75434ff-f465-4b70-92e4-b7ba6b6c58ff",
+            expires_in = 299,
+        }
+    },
+    -- #8, plugin check the client token
+    {
+        expect = "/introspect-access-token",
+        required_fields = {
+            "oxd_id",
+            "access_token",
+        },
+        request_check = function(json, token)
+            assert(json.oxd_id == model[3].response.oxd_id)
+            assert(json.access_token == model[4].response.access_token)
+            assert(token == model[7].response.access_token, 403)
+        end,
+        response = {
+            active = true,
+            client_id = "@!1736.179E.AA60.16B2!0001!8F7C.B9AB!0008!A2BB.9AE6.5F14.B387", -- should be the same as return by register-site
+            username = "John Black",
+            scope = { "openid" },
+            token_type = "bearer",
+            sub = "jblack",
+            aud = "l238j323ds-23ij4",
+            iss = "https://as.gluu.org/",
+            --acr_values": ["basic","duo"],
+            --extension_field": "twenty-seven",
+        },
+        response_callback = function(response)
+            response.exp = ngx.now() + 60 * 60
+            response.iat = ngx.now()
+        end,
+    },
+}
+
+return model


### PR DESCRIPTION
This should close #281.

The assumption that Kong creates plugin instance per config was wrong.
It creates a singleton.

Now we cache access token on module level and per client_id.
It is also the optimization - if some plugins are configured with the same client_id they share access token.