### PR TITLE
Wildcard regexp path

### DIFF
--- a/kong/common/path-wildcard-tree.lua
+++ b/kong/common/path-wildcard-tree.lua
@@ -1,0 +1,201 @@
+local gmatch = string.gmatch
+local function path_plit(s)
+    local result = {};
+    for match in (s):gmatch([[/([^/]*)]]) do
+        result[#result + 1] = match
+    end
+    return result
+end
+
+local WILDCARD_ELEMENT = "?"
+local WILDCARD_MULTIPLE_ELEMENTS = "??"
+
+local _M = {}
+
+local EXPRESSION_KEY = "#"
+
+_M.addPath = function(self, path, exp)
+    -- TODO here must be special version of split with {regexp} support
+    -- or should we forbid slash within regexp?
+    local path_as_array = path_plit(path)
+
+    local node = self
+    for i = 1, #path_as_array do
+        local item = path_as_array[i]
+
+        if item == WILDCARD_ELEMENT then
+            if not node[WILDCARD_ELEMENT] then
+                node[WILDCARD_ELEMENT] = {}
+            end
+            node = node[WILDCARD_ELEMENT]
+        elseif item == WILDCARD_MULTIPLE_ELEMENTS then
+            if not node[WILDCARD_MULTIPLE_ELEMENTS] then
+                node[WILDCARD_MULTIPLE_ELEMENTS] = {}
+            end
+            node = node[WILDCARD_MULTIPLE_ELEMENTS]
+        else
+            local regexp = item:match"^{(.+)}$"
+            if regexp then
+                node[#node + 1] = { regexp }
+                node = node[#node]
+            else
+                if not node[item] then
+                    node[item] = {}
+                end
+                node = node[item]
+            end
+        end
+    end
+    node[EXPRESSION_KEY] = exp
+end
+
+local function isNotKeysExist(t)
+    for k,v in pairs(t) do
+        if k ~= EXPRESSION_KEY then
+            return false
+        end
+    end
+    return true
+end
+
+local function serialize(val, stringOnlyKeys)
+    stringOnlyKeys = stringOnlyKeys or false
+    -- here cannot be userdata
+
+    local function serializeInternal(val, name, t, depth, stringOnlyKeys)
+        local vt = type(val)
+        if vt == "function" or vt == "thread" or vt == "userdata" then
+            return
+        end
+
+        depth = depth - 1
+        if depth == 0 then
+            return
+        end
+
+        if name then
+            t[#t + 1] = "["
+            if type(name) == "string" then
+                t[#t + 1] = string.format("%q", name)
+            else
+                t[#t + 1] = tostring(name)
+            end
+            t[#t + 1] = "]"
+            t[#t + 1] = " = "
+        end
+        if vt == "table" then
+            t[#t + 1] = "{"
+            for k, v in pairs(val) do
+                if stringOnlyKeys and type(k) == "string" then
+                    serializeInternal(v, k, t, depth)
+                elseif not stringOnlyKeys then
+                    serializeInternal(v, k, t, depth)
+                end
+            end
+            t[#t + 1] = "}"
+        elseif vt == "number" then
+            t[#t + 1] = tostring(val)
+        elseif vt == "string" then
+            t[#t + 1] = string.format("%q", val)
+        elseif vt == "boolean" then
+            t[#t + 1] = tostring(val)
+        end
+
+        if name then
+            t[#t + 1] = ","
+        end
+    end
+
+    local t = {}
+    local depth = 100 -- limit nested levels
+
+    serializeInternal(val, nil, t, depth)
+
+    return table.concat(t)
+end
+
+local function isKeysExist(t)
+    for k,v in pairs(t) do
+        if k ~= EXPRESSION_KEY then
+            return true
+        end
+    end
+    return false
+end
+
+local function processItem(node, path_as_array, index)
+    local item = path_as_array[index]
+    local key_node = node[item]
+
+    -- first looking for exact match
+    if key_node then
+        return key_node
+    end
+
+    -- next check regexp match
+    for i = 1, #node do
+        local regexp = node[i][1]
+        local m, err = ngx.re.match(item, regexp, "jo")
+        if m then
+            return node[i]
+        end
+    end
+
+    local wildcard_node = node[WILDCARD_ELEMENT]
+    if wildcard_node then
+        return wildcard_node
+    end
+
+    local wildcard_multiple_node = node[WILDCARD_MULTIPLE_ELEMENTS]
+    if wildcard_multiple_node then
+
+        if isKeysExist(wildcard_multiple_node) then
+            for skip = -1, #path_as_array - index do
+                local node_local = wildcard_multiple_node
+                local matched, last_index
+                for  j = 1, #path_as_array - index - skip do
+                    node_local, matched = processItem(node_local, path_as_array, index + skip + j)
+
+                    -- we allow only one multiple wildcard, so processItem cannot return matched == true
+                    if not node_local then
+                        break
+                    end
+                    last_index = index + skip + j
+                end
+
+                if last_index == #path_as_array and node_local[EXPRESSION_KEY] then
+                    return node_local, true
+                end
+            end
+        end
+
+        if wildcard_multiple_node[EXPRESSION_KEY] then
+            return wildcard_multiple_node, true
+        end
+
+    end
+end
+
+_M.matchPath = function(self, path)
+    local path_as_array = path_plit(path)
+
+    local node = self
+    local matched, last_index
+
+    for i = 1, #path_as_array do
+        node, matched = processItem(node, path_as_array, i)
+        if matched then
+            return node[EXPRESSION_KEY]
+        end
+        if not node then
+            break
+        end
+        last_index = i
+    end
+
+    if last_index == #path_as_array and node[EXPRESSION_KEY] then
+        return node[EXPRESSION_KEY]
+    end
+end
+
+return _M

--- a/kong/plugins/gluu-oauth-pep/access.lua
+++ b/kong/plugins/gluu-oauth-pep/access.lua
@@ -45,10 +45,9 @@ end
 -- @return json expression Example: {path: "/posts", ...}
 function hooks.get_path_by_request_path_method(self, conf, path, method)
     local exp = conf.oauth_scope_expression
-    -- TODO the complexity is O(N), think how to optimize
 
     local method_path_tree = conf.method_path_tree
-    local rule = path_wildcard_tree.matchPath(method_path_tree, table.concat{"/", method, path})
+    local rule = path_wildcard_tree.matchPath(method_path_tree, method, path)
 
     if rule then
         return rule.path, rule.scope_expression

--- a/kong/plugins/gluu-oauth-pep/access.lua
+++ b/kong/plugins/gluu-oauth-pep/access.lua
@@ -1,4 +1,5 @@
 local kong_auth_pep_common = require "gluu.kong-common"
+local path_wildcard_tree = require"gluu.path-wildcard-tree"
 local pl_tablex = require "pl.tablex"
 local logic = require "rucciva.json_logic"
 
@@ -31,6 +32,10 @@ end
 
 local hooks = {}
 
+local function strip_method(path)
+
+end
+
 --- Fetch oauth scope expression based on path and http methods
 -- Details: https://github.com/GluuFederation/gluu-gateway/issues/179#issuecomment-403453890
 -- @param self: Kong plugin object
@@ -41,21 +46,12 @@ local hooks = {}
 function hooks.get_path_by_request_path_method(self, conf, path, method)
     local exp = conf.oauth_scope_expression
     -- TODO the complexity is O(N), think how to optimize
-    local found_paths = {}
-    for i = 1, #exp do
-        if kong_auth_pep_common.is_path_match(path, exp[i]["path"]) then
-            found_paths[#found_paths + 1] = exp[i]
-        end
-    end
 
-    for i = 1, #found_paths do
-        local conditions = found_paths[i].conditions
-        for k = 1, #conditions do
-            local rule = conditions[k]
-            if pl_tablex.find(rule.httpMethods, method) then
-                return found_paths[i].path, rule.scope_expression
-            end
-        end
+    local method_path_tree = conf.method_path_tree
+    local rule = path_wildcard_tree.matchPath(method_path_tree, table.concat{"/", method, path})
+
+    if rule then
+        return rule.path, rule.scope_expression
     end
 
     return nil

--- a/kong/plugins/gluu-oauth-pep/schema.lua
+++ b/kong/plugins/gluu-oauth-pep/schema.lua
@@ -31,7 +31,7 @@ return {
 
                 for j = 1, #condition.httpMethods do
                     local t = { path = item.path, scope_expression = condition.scope_expression }
-                    path_wildcard_tree.addPath(method_path_tree, "/" .. condition.httpMethods[j] .. item.path, t)
+                    path_wildcard_tree.addPath(method_path_tree, condition.httpMethods[j], item.path, t)
                 end
             end
         end

--- a/kong/plugins/gluu-oauth-pep/schema.lua
+++ b/kong/plugins/gluu-oauth-pep/schema.lua
@@ -1,4 +1,4 @@
-local kong_auth_pep_common = require"gluu.kong-common"
+local path_wildcard_tree = require "gluu.path-wildcard-tree"
 
 --- Check OAuth scope expression
 -- @param v: JSON expression
@@ -17,14 +17,25 @@ return {
         op_url = { required = true, type = "url" },
         oxd_url = { required = true, type = "url" },
         oauth_scope_expression = { required = false, type = "table", func = check_expression },
-        deny_by_default = { type = "boolean", default = true }
+        deny_by_default = { type = "boolean", default = true },
+        method_path_tree = { required = false, type = "table" },
     },
     self_check = function(schema, plugin_t, dao, is_updating)
-        if not plugin_t.ignore_scope then
-            table.sort(plugin_t.oauth_scope_expression, function(first, second)
-                return #first.path > #second.path
-            end)
+        local method_path_tree = {}
+        local oauth_scope_expression = plugin_t.oauth_scope_expression
+        for k = 1, #oauth_scope_expression do
+            local item = oauth_scope_expression[k]
+
+            for i = 1, #item.conditions do
+                local condition = item.conditions[i]
+
+                for j = 1, #condition.httpMethods do
+                    local t = { path = item.path, scope_expression = condition.scope_expression }
+                    path_wildcard_tree.addPath(method_path_tree, "/" .. condition.httpMethods[j] .. item.path, t)
+                end
+            end
         end
+        plugin_t.method_path_tree = method_path_tree
         return true
     end
 }

--- a/kong/plugins/gluu-uma-pep/schema.lua
+++ b/kong/plugins/gluu-uma-pep/schema.lua
@@ -1,3 +1,5 @@
+local path_wildcard_tree = require "gluu.path-wildcard-tree"
+
 --- Check UMA protection document
 -- @param v: JSON expression
 local function check_expression(v)
@@ -14,6 +16,7 @@ return {
         oxd_id = { required = true, type = "string" },
         op_url = { required = true, type = "url" },
         uma_scope_expression = { required = true, func = check_expression, type = "table" },
+        method_path_tree = { required = false, type = "table" },
         deny_by_default = { type = "boolean", default = true },
         require_id_token = { type = "boolean", default = false },
         obtain_rpt = { type = "boolean", default = false },
@@ -21,9 +24,21 @@ return {
         redirect_claim_gathering_url = { type = "boolean", default = false },
     },
     self_check = function(schema, plugin_t, dao, is_updating)
-        table.sort(plugin_t.uma_scope_expression, function(first, second)
-            return #first.path > #second.path
-        end)
+        local method_path_tree = {}
+        local uma_scope_expression = plugin_t.uma_scope_expression
+        for k = 1, #uma_scope_expression do
+            local item = uma_scope_expression[k]
+
+            for i = 1, #item.conditions do
+                local condition = item.conditions[i]
+
+                for j = 1, #condition.httpMethods do
+                    local t = { path = item.path }
+                    path_wildcard_tree.addPath(method_path_tree, condition.httpMethods[j], item.path, t)
+                end
+            end
+        end
+        plugin_t.method_path_tree = method_path_tree
         return true
     end
 }

--- a/t/specs/gluu-oauth-pep/test_spec.lua
+++ b/t/specs/gluu-oauth-pep/test_spec.lua
@@ -45,6 +45,7 @@ local function setup(model)
             ["prometheus.lua"] = host_git_root .. "/third-party/nginx-lua-prometheus/prometheus.lua",
             ["gluu/oxdweb.lua"] = host_git_root .. "/third-party/oxd-web-lua/oxdweb.lua",
             ["gluu/kong-common.lua"] = host_git_root .. "/kong/common/kong-common.lua",
+            ["gluu/path-wildcard-tree.lua"] = host_git_root .. "/kong/common/path-wildcard-tree.lua",
             ["resty/lrucache.lua"] = host_git_root .. "/third-party/lua-resty-lrucache/lib/resty/lrucache.lua",
             ["resty/lrucache/pureffi.lua"] = host_git_root .. "/third-party/lua-resty-lrucache/lib/resty/lrucache/pureffi.lua",
             ["rucciva/json_logic.lua"] = host_git_root .. "/third-party/json-logic-lua/logic.lua",
@@ -426,7 +427,7 @@ test("check oauth_scope_expression and metrics", function()
     configure_pep_plugin(register_site_response, create_service_response, {
         oauth_scope_expression = {
             {
-                path = "/",
+                path = "/??",
                 conditions = {
                     {
                         scope_expression = {

--- a/t/specs/gluu-openid-connect/oxd-model2.lua
+++ b/t/specs/gluu-openid-connect/oxd-model2.lua
@@ -166,6 +166,66 @@ model = {
         response = {
             access = "granted",
         },
+    },
+    -- #9, Get ticket for path "/page2/{todos|photos}"
+    {
+        expect = "/uma-rs-check-access",
+        required_fields = {
+            "oxd_id",
+            "rpt",
+            "path",
+            "http_method",
+        },
+        request_check = function(json, token)
+            assert(json.oxd_id == model[1].response.oxd_id)
+            assert(token == model[2].response.access_token)
+            assert(json.path == "/page2/{todos|photos}")
+            assert(json.http_method == "GET")
+            assert(json.rpt == "")
+        end,
+        response = {
+            access = "denied",
+            ["www-authenticate_header"] = "UMA realm=\"rs\",as_uri=\"https://op-hostname\",error=\"insufficient_scope\",ticket=\"e986fd2b-de83-4947-a889-8f63c7c409c0\"",
+            ticket = "e986fd2b-de83-4947-a889-8f63c7c409c0"
+        },
+    },
+    -- #10, Obtain RPT for path "/page2/{todos|photos}"
+    {
+        expect = "/uma-rp-get-rpt",
+        required_fields = {
+            "oxd_id",
+            "ticket"
+        },
+        request_check = function(json, token)
+            assert(json.oxd_id == model[1].response.oxd_id)
+            assert(token == model[2].response.access_token)
+            assert(json.ticket == model[9].response.ticket)
+        end,
+        response = {
+            access_token = "b75434ff-f465-4b70-92e4-b7ba6b6c58f3",
+            pct = "pct",
+            token_type = "bearer"
+        },
+    },
+    -- #11, plugin check_access with RPT, "/page2/{todos|photos}", GET
+    {
+        expect = "/uma-rs-check-access",
+        required_fields = {
+            "oxd_id",
+            "rpt",
+            "path",
+            "http_method",
+        },
+        request_check = function(json, token)
+            assert(json.oxd_id == model[1].response.oxd_id)
+            assert(token == model[2].response.access_token)
+            assert(json.path == "/page2/{todos|photos}")
+            assert(json.http_method == "GET")
+            assert(json.rpt ==  model[10].response.access_token)
+        end,
+        response = {
+            access = "granted",
+        },
     }
 }
 

--- a/t/specs/gluu-openid-connect/oxd-model2.lua
+++ b/t/specs/gluu-openid-connect/oxd-model2.lua
@@ -226,6 +226,66 @@ model = {
         response = {
             access = "granted",
         },
+    },
+    -- #12, Get ticket for path "/path/?/image.jpg"
+    {
+        expect = "/uma-rs-check-access",
+        required_fields = {
+            "oxd_id",
+            "rpt",
+            "path",
+            "http_method",
+        },
+        request_check = function(json, token)
+            assert(json.oxd_id == model[1].response.oxd_id)
+            assert(token == model[2].response.access_token)
+            assert(json.path == "/path/?/image.jpg")
+            assert(json.http_method == "GET")
+            assert(json.rpt == "")
+        end,
+        response = {
+            access = "denied",
+            ["www-authenticate_header"] = "UMA realm=\"rs\",as_uri=\"https://op-hostname\",error=\"insufficient_scope\",ticket=\"e986fd2b-de83-4947-a889-8f63c7c409c0\"",
+            ticket = "e986fd2b-de83-4947-a889-8f63c7c409c0"
+        },
+    },
+    -- #13, Obtain RPT for path "/path/?/image.jpg"
+    {
+        expect = "/uma-rp-get-rpt",
+        required_fields = {
+            "oxd_id",
+            "ticket"
+        },
+        request_check = function(json, token)
+            assert(json.oxd_id == model[1].response.oxd_id)
+            assert(token == model[2].response.access_token)
+            assert(json.ticket == model[12].response.ticket)
+        end,
+        response = {
+            access_token = "b75434ff-f465-4b70-92e4-b7ba6b6c58f4",
+            pct = "pct",
+            token_type = "bearer"
+        },
+    },
+    -- #14, plugin check_access with RPT, "/path/?/image.jpg", GET
+    {
+        expect = "/uma-rs-check-access",
+        required_fields = {
+            "oxd_id",
+            "rpt",
+            "path",
+            "http_method",
+        },
+        request_check = function(json, token)
+            assert(json.oxd_id == model[1].response.oxd_id)
+            assert(token == model[2].response.access_token)
+            assert(json.path == "/path/?/image.jpg")
+            assert(json.http_method == "GET")
+            assert(json.rpt ==  model[13].response.access_token)
+        end,
+        response = {
+            access = "granted",
+        },
     }
 }
 

--- a/t/specs/gluu-openid-connect/test_spec.lua
+++ b/t/specs/gluu-openid-connect/test_spec.lua
@@ -331,7 +331,7 @@ test("OpenID Connect with UMA", function()
 
     print"request to another path /path/one/two/image.jpg"
     local res, err = sh_ex([[curl -i --fail -sS -X GET --url http://localhost:]],
-        ctx.kong_proxy_port, [[/path/?/image.jpg --header 'Host: backend.com' -c ]], cookie_tmp_filename,
+        ctx.kong_proxy_port, [[/path/123/image.jpg --header 'Host: backend.com' -c ]], cookie_tmp_filename,
         [[ -b ]], cookie_tmp_filename)
     assert(res:find("200", 1, true))
     assert(res:find("x-openid-connect-idtoken", 1, true))

--- a/t/specs/gluu-openid-connect/test_spec.lua
+++ b/t/specs/gluu-openid-connect/test_spec.lua
@@ -264,6 +264,14 @@ test("OpenID Connect with UMA", function()
                             httpMethods = {"GET"},
                         }
                     }
+                },
+                {
+                    path = "/page2/{todos|photos}",
+                    conditions = {
+                        {
+                            httpMethods = {"GET"},
+                        }
+                    }
                 }
             },
             deny_by_default = true,
@@ -300,6 +308,14 @@ test("OpenID Connect with UMA", function()
     print"request third time with cookie"
     local res, err = sh_ex([[curl -i --fail -sS -X GET --url http://localhost:]],
         ctx.kong_proxy_port, [[/page1 --header 'Host: backend.com' -c ]], cookie_tmp_filename,
+        [[ -b ]], cookie_tmp_filename)
+    assert(res:find("200", 1, true))
+    assert(res:find("x-openid-connect-idtoken", 1, true))
+    assert(res:find("x-openid-connect-userinfo", 1, true))
+
+    print"request to another path page2/photos"
+    local res, err = sh_ex([[curl -i --fail -sS -X GET --url http://localhost:]],
+        ctx.kong_proxy_port, [[/page2/photos --header 'Host: backend.com' -c ]], cookie_tmp_filename,
         [[ -b ]], cookie_tmp_filename)
     assert(res:find("200", 1, true))
     assert(res:find("x-openid-connect-idtoken", 1, true))

--- a/t/specs/gluu-openid-connect/test_spec.lua
+++ b/t/specs/gluu-openid-connect/test_spec.lua
@@ -50,6 +50,7 @@ local function setup(model)
         modules = {
             ["gluu/oxdweb.lua"] = host_git_root .. "/third-party/oxd-web-lua/oxdweb.lua",
             ["gluu/kong-common.lua"] = host_git_root .. "/kong/common/kong-common.lua",
+            ["gluu/path-wildcard-tree.lua"] = host_git_root .. "/kong/common/path-wildcard-tree.lua",
             ["resty/jwt.lua"] = host_git_root .. "/third-party/lua-resty-jwt/lib/resty/jwt.lua",
             ["resty/evp.lua"] = host_git_root .. "/third-party/lua-resty-jwt/lib/resty/evp.lua",
             ["resty/jwt-validators.lua"] = host_git_root .. "/third-party/lua-resty-jwt/lib/resty/jwt-validators.lua",

--- a/t/specs/gluu-openid-connect/test_spec.lua
+++ b/t/specs/gluu-openid-connect/test_spec.lua
@@ -272,6 +272,14 @@ test("OpenID Connect with UMA", function()
                             httpMethods = {"GET"},
                         }
                     }
+                },
+                {
+                    path = "/path/?/image.jpg",
+                    conditions = {
+                        {
+                            httpMethods = {"GET"},
+                        }
+                    }
                 }
             },
             deny_by_default = true,
@@ -316,6 +324,14 @@ test("OpenID Connect with UMA", function()
     print"request to another path page2/photos"
     local res, err = sh_ex([[curl -i --fail -sS -X GET --url http://localhost:]],
         ctx.kong_proxy_port, [[/page2/photos --header 'Host: backend.com' -c ]], cookie_tmp_filename,
+        [[ -b ]], cookie_tmp_filename)
+    assert(res:find("200", 1, true))
+    assert(res:find("x-openid-connect-idtoken", 1, true))
+    assert(res:find("x-openid-connect-userinfo", 1, true))
+
+    print"request to another path /path/one/two/image.jpg"
+    local res, err = sh_ex([[curl -i --fail -sS -X GET --url http://localhost:]],
+        ctx.kong_proxy_port, [[/path/?/image.jpg --header 'Host: backend.com' -c ]], cookie_tmp_filename,
         [[ -b ]], cookie_tmp_filename)
     assert(res:find("200", 1, true))
     assert(res:find("x-openid-connect-idtoken", 1, true))

--- a/t/specs/gluu-uma-auth/test_spec.lua
+++ b/t/specs/gluu-uma-auth/test_spec.lua
@@ -38,7 +38,6 @@ local function setup(model)
     kong_utils.kong_postgress_custom_plugins{
         plugins = {
             ["gluu-uma-auth"] = host_git_root .. "/kong/plugins/gluu-uma-auth",
-            ["gluu-uma-pep"] = host_git_root .. "/kong/plugins/gluu-uma-pep",
             ["gluu-metrics"] = host_git_root .. "/kong/plugins/gluu-metrics",
         },
         modules = {

--- a/t/specs/gluu-uma-pep/oxd-model1.lua
+++ b/t/specs/gluu-uma-pep/oxd-model1.lua
@@ -76,7 +76,7 @@ model = {
         request_check = function(json, token)
             assert(json.oxd_id == model[1].response.oxd_id)
             assert(token == model[3].response.access_token, 403)
-            assert(json.path == "/")
+            assert(json.path == "/??")
             assert(json.http_method == "GET")
             assert(json.rpt == "")
         end,
@@ -120,7 +120,7 @@ model = {
         request_check = function(json, token)
             assert(json.oxd_id == model[1].response.oxd_id)
             assert(token == model[3].response.access_token, 403)
-            assert(json.path == "/")
+            assert(json.path == "/??")
             assert(json.http_method == "GET")
             assert(json.rpt == "1234567890")
         end,
@@ -221,7 +221,7 @@ model = {
         request_check = function(json, token)
             assert(json.oxd_id == model[1].response.oxd_id)
             assert(token == model[3].response.access_token, 403)
-            assert(json.path == "/")
+            assert(json.path == "/??")
             assert(json.http_method == "GET")
             assert(json.rpt == "POSTS1234567890")
         end,

--- a/t/specs/gluu-uma-pep/test_spec.lua
+++ b/t/specs/gluu-uma-pep/test_spec.lua
@@ -45,6 +45,7 @@ local function setup(model)
             ["prometheus.lua"] = host_git_root .. "/third-party/nginx-lua-prometheus/prometheus.lua",
             ["gluu/oxdweb.lua"] = host_git_root .. "/third-party/oxd-web-lua/oxdweb.lua",
             ["gluu/kong-common.lua"] = host_git_root .. "/kong/common/kong-common.lua",
+            ["gluu/path-wildcard-tree.lua"] = host_git_root .. "/kong/common/path-wildcard-tree.lua",
             ["resty/lrucache.lua"] = host_git_root .. "/third-party/lua-resty-lrucache/lib/resty/lrucache.lua",
             ["resty/lrucache/pureffi.lua"] = host_git_root .. "/third-party/lua-resty-lrucache/lib/resty/lrucache/pureffi.lua",
             ["resty/jwt.lua"] = host_git_root .. "/third-party/lua-resty-jwt/lib/resty/jwt.lua",

--- a/t/specs/gluu-uma-pep/test_spec.lua
+++ b/t/specs/gluu-uma-pep/test_spec.lua
@@ -196,7 +196,7 @@ test("with and without token, metrics, uma-auth and check UMA scope", function()
         {
             uma_scope_expression = {
                 {
-                    path = "/",
+                    path = "/??",
                     conditions = {
                         {
                             httpMethods = {"GET"},

--- a/t/specs/path-wildcard-tree/path-wildcard-tree-tester.lua
+++ b/t/specs/path-wildcard-tree/path-wildcard-tree-tester.lua
@@ -65,7 +65,7 @@ function _M.add()
 
     local data = ngx.req.get_body_data()
 
-    path_wildcard_tree.addPath(tree, data, { path = data } )
+    path_wildcard_tree.addPath(tree, "GET", data, { path = data } )
 
     ngx.say(serialize(tree))
 end
@@ -75,7 +75,7 @@ function _M.match()
 
     local data = ngx.req.get_body_data()
 
-    local node = path_wildcard_tree.matchPath(tree, data)
+    local node = path_wildcard_tree.matchPath(tree, "GET", data)
 
     if node then
         ngx.say(node.path)

--- a/t/specs/path-wildcard-tree/path-wildcard-tree-tester.lua
+++ b/t/specs/path-wildcard-tree/path-wildcard-tree-tester.lua
@@ -1,0 +1,88 @@
+local path_wildcard_tree = require"gluu.path-wildcard-tree"
+
+local _M = {}
+
+local tree = {}
+
+local function serialize(val, stringOnlyKeys)
+    stringOnlyKeys = stringOnlyKeys or false
+    -- here cannot be userdata
+
+    local function serializeInternal(val, name, t, depth, stringOnlyKeys)
+        local vt = type(val)
+        if vt == "function" or vt == "thread" or vt == "userdata" then
+            return
+        end
+
+        depth = depth - 1
+        if depth == 0 then
+            return
+        end
+
+        if name then
+            t[#t + 1] = "["
+            if type(name) == "string" then
+                t[#t + 1] = string.format("%q", name)
+            else
+                t[#t + 1] = tostring(name)
+            end
+            t[#t + 1] = "]"
+            t[#t + 1] = " = "
+        end
+        if vt == "table" then
+            t[#t + 1] = "{"
+            for k, v in pairs(val) do
+                if stringOnlyKeys and type(k) == "string" then
+                    serializeInternal(v, k, t, depth)
+                elseif not stringOnlyKeys then
+                    serializeInternal(v, k, t, depth)
+                end
+            end
+            t[#t + 1] = "}"
+        elseif vt == "number" then
+            t[#t + 1] = tostring(val)
+        elseif vt == "string" then
+            t[#t + 1] = string.format("%q", val)
+        elseif vt == "boolean" then
+            t[#t + 1] = tostring(val)
+        end
+
+        if name then
+            t[#t + 1] = ","
+        end
+    end
+
+    local t = {}
+    local depth = 100 -- limit nested levels
+
+    serializeInternal(val, nil, t, depth)
+
+    return table.concat(t)
+end
+
+function _M.add()
+    ngx.req.read_body()
+
+    local data = ngx.req.get_body_data()
+
+    path_wildcard_tree.addPath(tree, data, { path = data } )
+
+    ngx.say(serialize(tree))
+end
+
+function _M.match()
+    ngx.req.read_body()
+
+    local data = ngx.req.get_body_data()
+
+    local node = path_wildcard_tree.matchPath(tree, data)
+
+    if node then
+        ngx.say(node.path)
+    else
+        ngx.say"Not match"
+    end
+end
+
+return _M
+

--- a/t/specs/path-wildcard-tree/test.nginx
+++ b/t/specs/path-wildcard-tree/test.nginx
@@ -1,0 +1,29 @@
+worker_processes 1;
+
+error_log logs/error.log info;
+
+events {
+    worker_connections 512;
+}
+
+http {
+
+    server {
+        listen 80;
+
+        location = /add {
+            content_by_lua_block{
+                require "gluu.path-wildcard-tree-tester".add()
+            }
+        }
+
+        location = /match {
+            content_by_lua_block{
+                require "gluu.path-wildcard-tree-tester".match()
+            }
+        }
+
+
+    }
+}
+

--- a/t/specs/path-wildcard-tree/test_spec.lua
+++ b/t/specs/path-wildcard-tree/test_spec.lua
@@ -88,7 +88,7 @@ test("basic tests", function()
     local res, err = matchPath("/path/xyz/image.jpg")
     assert(res:find("/path/{abc|xyz}/image.jpg", 1 , true))
 
-    -- regexo doesn't match, wildcard does
+    -- regexp doesn't match, wildcard does
     local res, err = matchPath("/path/123/image.jpg")
     assert(res:find("/path/?/image.jpg", 1 , true))
 
@@ -98,6 +98,7 @@ test("basic tests", function()
     assert(res:find("/users/?/{todos|photos}", 1 , true))
 
     addPath("/users/?/{todos|photos}/?")
+    addPath("/users/?/{todos|photos}/123")
 
     local res, err = matchPath("/users/123/todos/")
     assert(res:find("/users/?/{todos|photos}/?", 1 , true))
@@ -105,8 +106,8 @@ test("basic tests", function()
     local res, err = matchPath("/users/123/todos/321")
     assert(res:find("/users/?/{todos|photos}/?", 1 , true))
 
-    local res, err = matchPath("/users/123/todos/321")
-    assert(res:find("/users/?/{todos|photos}/?", 1 , true))
+    local res, err = matchPath("/users/123/todos/123")
+    assert(res:find("/users/?/{todos|photos}/123", 1 , true))
 
     print_logs = false
 end)

--- a/t/specs/path-wildcard-tree/test_spec.lua
+++ b/t/specs/path-wildcard-tree/test_spec.lua
@@ -51,10 +51,16 @@ test("basic tests", function()
 
     addPath("/folder/?/file")
 
+    local res, err = matchPath("/folder/?/file")
+    assert(res:find("/folder/?/file", 1 , true))
+
     local res, err = matchPath("/folder/xxx/file")
     assert(res:find("/folder/?/file", 1 , true))
 
     addPath("/path/??")
+
+    local res, err = matchPath("/path/??")
+    assert(res:find("/path/??", 1 , true))
 
     local res, err = matchPath("/path/xxx/file")
     assert(res:find("/path/??", 1 , true))
@@ -68,6 +74,9 @@ test("basic tests", function()
 
     addPath("/path/??/image.jpg")
 
+    local res, err = matchPath("/path/??/image.jpg")
+    assert(res:find("/path/??/image.jpg", 1 , true))
+
     local res, err = matchPath("/path/one/two/image.jpg")
     assert(res:find("/path/??/image.jpg", 1 , true))
 
@@ -75,6 +84,9 @@ test("basic tests", function()
     assert(res:find("/path/??/image.jpg", 1 , true))
 
     addPath("/path/?/image.jpg")
+
+    local res, err = matchPath("/path/?/image.jpg")
+    assert(res:find("/path/?/image.jpg", 1 , true))
 
     -- ensure wildcard has a prioroty on multiple wildcard
     local res, err = matchPath("/path/xxx/image.jpg")

--- a/t/specs/path-wildcard-tree/test_spec.lua
+++ b/t/specs/path-wildcard-tree/test_spec.lua
@@ -1,0 +1,96 @@
+local utils = require"test_utils"
+local sh, stdout, stderr, sleep, sh_ex, sh_until_ok =
+utils.sh, utils.stdout, utils.stderr, utils.sleep, utils.sh_ex, utils.sh_until_ok
+
+local host_git_root = os.getenv "HOST_GIT_ROOT"
+local git_root = os.getenv "GIT_ROOT"
+
+local function docker_run()
+    return stdout("docker run -d --rm -p 80",
+        " -v ", host_git_root, "/t/specs/path-wildcard-tree/test.nginx:/usr/local/openresty/nginx/conf/nginx.conf:ro ",
+        " -v ", host_git_root, "/kong/common/path-wildcard-tree.lua:/usr/local/openresty/lualib/gluu/path-wildcard-tree.lua:ro ",
+        " -v ", host_git_root, "/t/specs/path-wildcard-tree/path-wildcard-tree-tester.lua:/usr/local/openresty/lualib/gluu/path-wildcard-tree-tester.lua:ro ",
+        " openresty/openresty:alpine")
+end
+
+local nginx_port
+
+local function addPath(path)
+    return sh_ex([[curl -sS -v --fail -m 5 -L -X POST -H "Content-Type: text/plain" --data "]]
+        ,path,[["  "127.0.0.1:]], nginx_port, "/add\"")
+end
+
+local function matchPath(path)
+    return sh_ex([[curl -sS -v --fail -m 5 -L -X POST -H "Content-Type: text/plain" --data "]]
+        ,path,[["  "127.0.0.1:]], nginx_port, "/match\"")
+end
+
+test("basic tests", function()
+
+    local container_id = docker_run()
+
+    local print_logs = true
+    finally(function()
+        -- useful for debug
+        if print_logs then
+            sh("docker logs ", container_id)
+        end
+
+        sh("docker stop ", container_id)
+    end)
+
+    nginx_port = stdout("docker inspect --format='{{(index (index .NetworkSettings.Ports \"80/tcp\") 0).HostPort}}' ", container_id)
+
+    addPath("/folder/file.ext")
+
+    local res, err = matchPath("/folder/file.ext")
+    assert(res:find("/folder/file.ext", 1 , true))
+
+    local res, err = matchPath("/folder/file")
+    assert(res:find("Not match"))
+
+    addPath("/folder/?/file")
+
+    local res, err = matchPath("/folder/xxx/file")
+    assert(res:find("/folder/?/file", 1 , true))
+
+    addPath("/path/??")
+
+    local res, err = matchPath("/path/xxx/file")
+    assert(res:find("/path/??", 1 , true))
+
+    local res, err = matchPath("/path/")
+    assert(res:find("/path/??", 1 , true))
+
+    -- slash is required before multiple wildcards placeholder
+    local res, err = matchPath("/path")
+    assert(res:find("Not match"))
+
+    addPath("/path/??/image.jpg")
+
+    local res, err = matchPath("/path/one/two/image.jpg")
+    assert(res:find("/path/??/image.jpg", 1 , true))
+
+    local res, err = matchPath("/path/image.jpg")
+    assert(res:find("/path/??/image.jpg", 1 , true))
+
+    addPath("/path/?/image.jpg")
+
+    -- ensure wildcard has a prioroty on multiple wildcard
+    local res, err = matchPath("/path/xxx/image.jpg")
+    assert(res:find("/path/?/image.jpg", 1 , true))
+
+    addPath("/path/{abc|xyz}/image.jpg")
+
+    local res, err = matchPath("/path/abc/image.jpg")
+    assert(res:find("/path/{abc|xyz}/image.jpg", 1 , true))
+
+    local res, err = matchPath("/path/xyz/image.jpg")
+    assert(res:find("/path/{abc|xyz}/image.jpg", 1 , true))
+
+    -- regexo doesn't match, wildcard does
+    local res, err = matchPath("/path/123/image.jpg")
+    assert(res:find("/path/?/image.jpg", 1 , true))
+
+    print_logs = false
+end)

--- a/t/specs/path-wildcard-tree/test_spec.lua
+++ b/t/specs/path-wildcard-tree/test_spec.lua
@@ -92,5 +92,21 @@ test("basic tests", function()
     local res, err = matchPath("/path/123/image.jpg")
     assert(res:find("/path/?/image.jpg", 1 , true))
 
+    addPath("/users/?/{todos|photos}")
+
+    local res, err = matchPath("/users/123/todos")
+    assert(res:find("/users/?/{todos|photos}", 1 , true))
+
+    addPath("/users/?/{todos|photos}/?")
+
+    local res, err = matchPath("/users/123/todos/")
+    assert(res:find("/users/?/{todos|photos}/?", 1 , true))
+
+    local res, err = matchPath("/users/123/todos/321")
+    assert(res:find("/users/?/{todos|photos}/?", 1 , true))
+
+    local res, err = matchPath("/users/123/todos/321")
+    assert(res:find("/users/?/{todos|photos}/?", 1 , true))
+
     print_logs = false
 end)


### PR DESCRIPTION
Close #179 

The main idea is to support 3 types of dynamic content:

- ? match any one path element
- ?? match zero or more path elements
- {regexp} - match single path element against PCRE

Some examples:

**`/`** - exact match of `/` path
**`/??`** - any path match

**`/country/?/city/?/{.+\.php}`**

**`/folder/??`** - prefix match, slash after `folder` must be present, otherwise, it doesn't match.
Keep in mind that `/folder/` also matches.

**`/folder/??/{.+\.jpg}`**
`/folder/image.jpg` - match
`/folder/subfolder/picture.jpg` - match
`/folder/x/y/z/picture.jpg` - match

If you need at least one subfolder - use `?` placeholder:
**`/folder/?/??/{.+\.jpg}`**

The current implementation supports only one `??` placeholder in a path.

Priorities:
1. Exact match
2. Regexp match
3. `?`
4. `??`
