### PR TITLE
341 oidc bug

### DIFF
--- a/kong/common/kong-common.lua
+++ b/kong/common/kong-common.lua
@@ -58,7 +58,7 @@ end
 -- here we store access tokens per client_id
 local access_tokens_per_client_id = {}
 
-local function get_protection_token(self, conf)
+local function get_protection_token(conf)
     local access_token = access_tokens_per_client_id[conf.client_id]
     if not access_token then
         access_token = { expire = 0 }
@@ -110,7 +110,7 @@ local supported_algs = {
 }
 
 local function refresh_jwks(self, conf, jwks)
-    local ptoken = get_protection_token(self, conf)
+    local ptoken = get_protection_token(conf)
 
     local response, err = oxd.get_jwks(conf.oxd_url,
         { op_host = conf.op_url },

--- a/kong/common/kong-common.lua
+++ b/kong/common/kong-common.lua
@@ -7,7 +7,8 @@ local validators = require "resty.jwt-validators"
 local cjson = require"cjson"
 local pl_tablex = require "pl.tablex"
 
-local EXPIRE_DELTA = 10
+-- EXPIRE_DELTA should be not big positive number, IMO in range from 2 to 10 seconds
+local EXPIRE_DELTA = 5
 local MAX_PENDING_SLEEPS = 40
 local PENDING_EXPIRE = 0.2
 local PENDING_TABLE = {}
@@ -59,19 +60,9 @@ end
 local access_tokens_per_client_id = {}
 
 local function get_protection_token(conf)
-    local access_token = access_tokens_per_client_id[conf.client_id]
-    if not access_token then
-        access_token = { expire = 0 }
-        access_tokens_per_client_id[conf.client_id] = access_token
-    end
-
-    local now = ngx.now()
-    kong.log.debug("Current datetime: ", now, " access_token.expire: ", access_token.expire)
-    if not access_token.token or access_token.expire < now + EXPIRE_DELTA then
-        if access_token.token then
-            access_token.expire = access_token.expire + EXPIRE_DELTA -- avoid multiple token requests
-        end
-        local response = oxd.get_client_token(conf.oxd_url,
+    local access_token_data = access_tokens_per_client_id[conf.client_id]
+    if not access_token_data then
+        local response, err = oxd.get_client_token(conf.oxd_url,
             {
                 client_id = conf.client_id,
                 client_secret = conf.client_secret,
@@ -79,25 +70,76 @@ local function get_protection_token(conf)
                 op_host = conf.op_url,
             })
 
-        local status = response.status
         local body = response.body
-
-        kong.log.debug("Protection access token -- status: ", status)
-        if status >= 300 or not body.access_token then
-            access_token.token = nil
-            access_token.expire = 0
-            return unexpected_error("Failed to get access token.")
+        if response.status >= 300 or not body.access_token then
+            access_tokens_per_client_id[conf.client_id] = nil
+            return unexpected_error("Failed to get access token")
         end
 
-        access_token.token = body.access_token
-        if body.expires_in then
-            access_token.expire = ngx.now() + body.expires_in
-        else
-            -- use once
-            access_token.expire = 0
+        access_token_data = body
+        access_token_data.expire = ngx.time() + body.expires_in
+        access_tokens_per_client_id[conf.client_id] = access_token_data
+        return access_token_data.access_token
+    end
+
+    local now = ngx.time()
+    local ptoken = access_token_data.token
+
+    kong.log.debug("Current datetime: ", now, " access_token_data.expire: ", access_token_data.expire)
+    if access_token_data.expire > now - EXPIRE_DELTA then
+        return access_token_data.access_token
+    end
+
+    if access_token_data.expire < now and access_token_data.refresh_pending then
+        -- refreshing access token is in progress, avoid multiple token requests
+        return access_token_data.access_token
+    end
+
+    -- token will expire soon, we are trying to refresh it
+    -- avoid multiple token requests
+    access_token_data.refresh_pending = true
+
+    local refresh_token = access_token_data.refresh_token
+
+    local response, err
+    if refresh_token then
+        local response, err = oxd.get_access_token_by_refresh_token(conf.oxd_url,
+            {
+                oxd_id = conf.oxd_id,
+                refresh_token = refresh_token,
+            },
+            ptoken)
+
+        local body = response.body
+        if response.status < 300 and body.access_token then
+            access_token_data = body
+            access_token_data.expire = ngx.time() + response.body.expires_in
+            access_tokens_per_client_id[conf.client_id] = access_token_data
+            access_token_data.refresh_pending = nil
+            return access_token_data.access_token
         end
     end
-    return access_token.token
+
+    -- last chance, get_access_token by client credentials
+    local response, err = oxd.get_client_token(conf.oxd_url,
+        {
+            client_id = conf.client_id,
+            client_secret = conf.client_secret,
+            scope = { "openid", "oxd" },
+            op_host = conf.op_url,
+        })
+
+    local body = response.body
+    if response.status >= 300 or not body.access_token then
+        access_tokens_per_client_id[conf.client_id] = nil
+        return unexpected_error("Failed to get access token, status: ", status)
+    end
+
+    access_token_data = body
+    access_token_data.refresh_pending = nil
+    access_token_data.expire = ngx.time() + body.expires_in
+    access_tokens_per_client_id[conf.client_id] = access_token_data
+    return access_token_data.access_token
 end
 
 -- here we store jwks per op_url

--- a/kong/plugins/gluu-oauth-auth/access.lua
+++ b/kong/plugins/gluu-oauth-auth/access.lua
@@ -5,7 +5,7 @@ local kong_auth_pep_common = require "gluu.kong-common"
 -- upon success returns only introspect_response,
 -- otherwise return nil, status, err
 local function introspect_token(self, conf, token)
-    local ptoken = kong_auth_pep_common.get_protection_token(self, conf)
+    local ptoken = kong_auth_pep_common.get_protection_token(conf)
 
     local response = oxd.introspect_access_token(conf.oxd_url,
         {

--- a/kong/plugins/gluu-openid-connect/access.lua
+++ b/kong/plugins/gluu-openid-connect/access.lua
@@ -29,8 +29,7 @@ local function process_logout(conf, session)
     local session_token = session.data.enc_id_token
     session:destroy()
 
-    -- TODO get rid of self parameter of get_protection_token(), make it as separate commit
-    local ptoken = kong_auth_pep_common.get_protection_token(nil, conf)
+    local ptoken = kong_auth_pep_common.get_protection_token(conf)
 
     local post_logout_redirect_uri
     if conf.post_logout_redirect_path_or_url:sub(1, 1) == "/" then
@@ -75,7 +74,7 @@ local function authorization_response(self, conf, session)
 
     kong.log.debug("Authentication with OP done -> Calling OP Token Endpoint to obtain tokens")
 
-    local ptoken = kong_auth_pep_common.get_protection_token(nil, conf)
+    local ptoken = kong_auth_pep_common.get_protection_token(conf)
 
     local response, err = oxd.get_tokens_by_code(conf.oxd_url,
         {
@@ -110,7 +109,7 @@ local function authorization_response(self, conf, session)
     session_data.access_token_expiration = ngx.time() + access_token_expires_in(conf, json.expires_in)
     session_data.refresh_token = json.refresh_token
 
-    local ptoken = kong_auth_pep_common.get_protection_token(nil, conf)
+    local ptoken = kong_auth_pep_common.get_protection_token(conf)
 
     local response, err = oxd.get_user_info(conf.oxd_url,
         {
@@ -153,7 +152,7 @@ local function refresh_access_token(conf, session)
 
     kong.log.debug("refreshing expired access_token: ", session_data.access_token, " with: ", session_data.refresh_token)
 
-    local ptoken = kong_auth_pep_common.get_protection_token(nil, conf)
+    local ptoken = kong_auth_pep_common.get_protection_token(conf)
 
     local response, err = oxd.get_access_token_by_refresh_token(conf.oxd_url,
         {
@@ -226,7 +225,7 @@ end
 -- send the browser of to the OP's authorization endpoint
 local function authorize(conf, session, prompt)
 
-    local ptoken = kong_auth_pep_common.get_protection_token(nil, conf)
+    local ptoken = kong_auth_pep_common.get_protection_token(conf)
 
     local response, err = oxd.get_authorization_url(conf.oxd_url,
         {

--- a/kong/plugins/gluu-openid-connect/access.lua
+++ b/kong/plugins/gluu-openid-connect/access.lua
@@ -100,10 +100,6 @@ local function authorization_response(self, conf, session)
     session_data.enc_id_token = json.id_token
     session_data.id_token = id_token
 
-    session_data.access_token = json.access_token
-    session_data.access_token_expiration = ngx.time() + json.expires_in
-    session_data.refresh_token = json.refresh_token
-
     local ptoken = kong_auth_pep_common.get_protection_token(conf)
 
     local response, err = oxd.get_user_info(conf.oxd_url,
@@ -131,57 +127,6 @@ local function authorization_response(self, conf, session)
     -- redirect to the URL that was accessed originally
     kong.log.debug("OIDC Authorization Code Flow completed -> Redirecting to original URL (", original_url, ")")
     ngx.redirect(original_url)
-end
-
--- EXPIRE_DELTA should be not big positive number, IMO in range from 2 to 10 seconds
--- kong-common also has similar const but for oxd AT
-local EXPIRE_DELTA = 5
-
-local function refresh_access_token(conf, session)
-    local current_time = ngx.time()
-    local session_data = session.data
-    if current_time < session_data.access_token_expiration - EXPIRE_DELTA then
-        return true
-    end
-
-    if not session_data.refresh_token then
-        kong.log.debug("token expired and no refresh token available")
-        return
-    end
-
-    kong.log.debug("refreshing expired access_token: ", session_data.access_token, " with: ", session_data.refresh_token)
-
-    local ptoken = kong_auth_pep_common.get_protection_token(conf)
-
-    local response, err = oxd.get_access_token_by_refresh_token(conf.oxd_url,
-        {
-            oxd_id = conf.oxd_id,
-            refresh_token = session_data.refresh_token,
-        },
-        ptoken)
-
-    if err then
-        kong.log.err(err)
-        return unexpected_error()
-    end
-
-    local status, json = response.status, response.body
-
-    if status ~= 200 then
-        kong.log.err("get_access_token_by_refresh_token() responds with status ", status)
-        return false
-    end
-
-    kong.log.debug("access_token refreshed: ", json.access_token, " updated refresh_token: ", json.refresh_token)
-
-    session_data.access_token = json.access_token
-    session_data.access_token_expiration = ngx.time() + json.expires_in
-    session_data.refresh_token = json.refresh_token
-
-    -- save the session with the new access_token and optionally the new refresh_token and id_token
-    session:save()
-
-    return true
 end
 
 local function is_acr_enough(required_acrs, acr)
@@ -307,23 +252,13 @@ return function(self, conf)
         return
     end
 
-    local token_expired = false
-    if session.present and session_data.id_token then
-        -- refresh access_token if necessary
-        if not refresh_access_token(conf, session) then
-            token_expired = true
-        end
-    end
-
     local id_token = session_data.id_token
     kong.log.debug(
         "session.present=", session.present,
-        ", session.data.id_token=", id_token ~= nil,
-        ", token_expired=", token_expired)
+        ", session.data.id_token=", id_token ~= nil)
 
     if not session.present
             or not id_token
-            or token_expired
             or (id_token.auth_time and (id_token.auth_time + conf.max_id_token_auth_age) < ngx.time()) then
         kong.log.debug("Authentication is required - Redirecting to OP Authorization endpoint")
         return authorize(conf, session)

--- a/kong/plugins/gluu-uma-auth/access.lua
+++ b/kong/plugins/gluu-uma-auth/access.lua
@@ -31,7 +31,7 @@ local function try_introspect_rpt(conf, token, access_token)
 end
 
 local function introspect_token(self, conf, token)
-    local ptoken = kong_auth_pep_common.get_protection_token(self, conf)
+    local ptoken = kong_auth_pep_common.get_protection_token(conf)
 
     local introspect_rpt_response_data = try_introspect_rpt(conf, token, ptoken)
     if not introspect_rpt_response_data.active then

--- a/kong/plugins/gluu-uma-pep/access.lua
+++ b/kong/plugins/gluu-uma-pep/access.lua
@@ -49,7 +49,7 @@ end
 local hooks = {}
 
 local function redirect_to_claim_url(conf, ticket)
-    local ptoken = kong_auth_pep_common.get_protection_token(nil, conf)
+    local ptoken = kong_auth_pep_common.get_protection_token(conf)
     local claims_redirect_uri = kong_auth_pep_common.get_path_with_base_url(conf.claims_redirect_path)
     local response, err = oxd.uma_rp_get_claims_gathering_url(conf.oxd_url,
         {
@@ -90,7 +90,7 @@ end
 
 -- call /uma_rp_get_rpt oxd API, handle errors
 local function get_rpt_by_ticket(self, conf, ticket, state, id_token_jwt)
-    local ptoken = kong_auth_pep_common.get_protection_token(self, conf)
+    local ptoken = kong_auth_pep_common.get_protection_token(conf)
 
     local requestBody = {
         oxd_id = conf.oxd_id,
@@ -145,7 +145,7 @@ function hooks.no_token_protected_path(self, conf, protected_path, method)
         return unexpected_error("Expect id_token")
     end
 
-    local ptoken = kong_auth_pep_common.get_protection_token(self, conf)
+    local ptoken = kong_auth_pep_common.get_protection_token(conf)
 
     local check_access_no_rpt_response = try_check_access(conf, protected_path, method, nil, ptoken)
 
@@ -160,7 +160,7 @@ function hooks.no_token_protected_path(self, conf, protected_path, method)
 end
 
 local function get_ticket(self, conf, protected_path, method)
-    local ptoken = kong_auth_pep_common.get_protection_token(self, conf)
+    local ptoken = kong_auth_pep_common.get_protection_token(conf)
 
     local check_access_no_rpt_response = try_check_access(conf, protected_path, method, nil, ptoken)
 
@@ -204,7 +204,7 @@ function hooks.is_access_granted(self, conf, protected_path, method, _, _, rpt)
         local id_token = kong.ctx.shared.request_token
         rpt =  get_rpt_by_ticket(self, conf, ticket, state, id_token)
     end
-    local ptoken = kong_auth_pep_common.get_protection_token(self, conf)
+    local ptoken = kong_auth_pep_common.get_protection_token(conf)
 
     local check_access_response = try_check_access(conf, protected_path, method, rpt, ptoken)
 

--- a/t/specs/gluu-openid-connect/oxd-model1.lua
+++ b/t/specs/gluu-openid-connect/oxd-model1.lua
@@ -107,25 +107,8 @@ model = {
             sub = "john doe",
         }
     },
-    -- #6 get_access_token_by_refresh_token
-    {
-        expect = "/get-access-token-by-refresh-token",
-        required_fields = {
-            "oxd_id",
-            "refresh_token",
-        },
-        request_check = function(json)
-            assert(json.oxd_id == model[1].response.oxd_id)
-            assert(json.refresh_token == model[4].response.refresh_token)
-        end,
-        response = {
-            access_token = "88bba7f5-961c-4b71-8053-9ab35f1ad333",
-            expires_in = 60,
-            refresh_token = "33d7988e-6ffb-4fe5-8c2a-0e158691d333"
-        }
-    },
 
-    -- #7 silent reauth
+    -- #6 silent reauth
     {
         expect = "/get-authorization-url",
         required_fields = {
@@ -139,7 +122,7 @@ model = {
             authorization_url = "https://stub.com/oxauth/restv1/authorize?response_type=code&client_id=@!1736.179E.AA60.16B2!0001!8F7C.B9AB!0008!A2BB.9AE6.AAA4&redirect_uri=https://192.168.200.95/callback&scope=openid+profile+email+uma_protection+uma_authorization&state=473ot4nuqb4ubeokc139raur13&nonce=lbrdgorr974q66q6q9g454iccm123",
         }
     },
-    -- #8
+    -- #7
     {
         expect = "/get-tokens-by-code",
         required_fields = {
@@ -171,7 +154,7 @@ model = {
             response.id_token_claims.auth_time = ngx.time()
         end
     },
-    -- #9
+    -- #8
     {
         expect = "/get-user-info",
         required_fields = {
@@ -180,7 +163,7 @@ model = {
         },
         request_check = function(json)
             assert(json.oxd_id == model[1].response.oxd_id)
-            assert(json.access_token == model[8].response.access_token)
+            assert(json.access_token == model[7].response.access_token)
         end,
         response = {
             sub = "john doe",

--- a/t/specs/gluu-openid-connect/test_spec.lua
+++ b/t/specs/gluu-openid-connect/test_spec.lua
@@ -219,16 +219,7 @@ test("basic", function()
     assert(res:find("x-openid-connect-idtoken", 1, true))
     assert(res:find("x-openid-connect-userinfo", 1, true))
 
-    sh_ex("sleep 10");
-    print"OIDC access token has 10 second expiration, should expire, request for new access token using refresh token"
-    local res, err = sh_ex([[curl -i --fail -sS -X GET --url http://localhost:]],
-        ctx.kong_proxy_port, [[/page1 --header 'Host: backend.com' -c ]], cookie_tmp_filename,
-        [[ -b ]], cookie_tmp_filename)
-    assert(res:find("200", 1, true))
-    assert(res:find("x-openid-connect-idtoken", 1, true))
-    assert(res:find("x-openid-connect-userinfo", 1, true))
-
-    sh_ex("sleep 6");
+    sh_ex("sleep 15");
 
     print"id_token is expired, require silent reauth"
     local res, err = sh_ex([[curl -i --fail -sS -X GET --url http://localhost:]],

--- a/t/specs/gluu-openid-connect/test_spec.lua
+++ b/t/specs/gluu-openid-connect/test_spec.lua
@@ -187,7 +187,7 @@ test("basic", function()
     configure_plugin(create_service_response,{
         authorization_redirect_path = "/callback",
         requested_scopes = {"openid", "email", "profile"},
-        max_id_token_age = 10,
+        max_id_token_age = 14,
         max_id_token_auth_age = 60*60*24,
         logout_path = "/logout_path",
         post_logout_redirect_path_or_url = "/post_logout_redirect_path_or_url"
@@ -219,9 +219,8 @@ test("basic", function()
     assert(res:find("x-openid-connect-idtoken", 1, true))
     assert(res:find("x-openid-connect-userinfo", 1, true))
 
-    sh_ex("sleep 15");
-
-    print"request for new access token using refresh token"
+    sh_ex("sleep 10");
+    print"OIDC access token has 10 second expiration, should expire, request for new access token using refresh token"
     local res, err = sh_ex([[curl -i --fail -sS -X GET --url http://localhost:]],
         ctx.kong_proxy_port, [[/page1 --header 'Host: backend.com' -c ]], cookie_tmp_filename,
         [[ -b ]], cookie_tmp_filename)
@@ -229,14 +228,25 @@ test("basic", function()
     assert(res:find("x-openid-connect-idtoken", 1, true))
     assert(res:find("x-openid-connect-userinfo", 1, true))
 
-    sh_ex("sleep 15");
-    print"Failed to get new access token, go for authentication"
+    sh_ex("sleep 6");
+
+    print"id_token is expired, require silent reauth"
     local res, err = sh_ex([[curl -i --fail -sS -X GET --url http://localhost:]],
         ctx.kong_proxy_port, [[/page1 --header 'Host: backend.com' -c ]], cookie_tmp_filename,
         [[ -b ]], cookie_tmp_filename)
     assert(res:find("302", 1, true))
     assert(res:find("response_type=code", 1, true))
-    assert(res:find("session=", 1, true))
+    assert(res:find("session=", 1, true)) -- session cookie is here
+
+    print"call callback with state from oxd-model1, follow redirect"
+    local res, err = sh_ex([[curl -i  -sS -X GET -L --url 'http://localhost:]],
+        ctx.kong_proxy_port, [[/callback?code=1234567890123&state=473ot4nuqb4ubeokc139raur13123' --header 'Host: backend.com']],
+        [[ -c ]], cookie_tmp_filename, [[ -b ]], cookie_tmp_filename)
+    -- test that we redirected to original url
+    assert(res:find("200", 1, true))
+    assert(res:find("page1", 1, true))
+    assert(res:find("x-openid-connect-idtoken", 1, true))
+    assert(res:find("x-openid-connect-userinfo", 1, true))
 
     print"logout and check the cookie"
     local res, err = sh_ex([[curl -i --fail -sS -X GET --url http://localhost:]],


### PR DESCRIPTION
Close #341 

This was not really bug, but one misconfiguration and wrong scenario.

Now all our plugins use refresh tokens (if any) to update access_token for oxd access.

We wrongly used the `max_id_token_age` for OIDC access token (get_user_info) also, fixed in a consistent way as oxd access tokens.

The test scenario and model have fixed, test both id_token silent refresh and get access_token by refresh token use cases.